### PR TITLE
Add 2012-June leap sec and change code logic based on new XTime.C

### DIFF
--- a/Chandra/XTime.cc
+++ b/Chandra/XTime.cc
@@ -35,9 +35,9 @@ const double XTime::TAI2TT      =      32.184   ; // TT - TAI
 int    XTime::NUMLEAPSECS = 0 ;      // Leap seconds: 1972 through 2009
 long   XTime::LEAPSMJD[]  = {41317, 41499, 41683, 42048, 42413, 42778, 43144, 43509, 43874,
 			     44239, 44786, 45151, 45516, 46247, 47161, 47892, 48257, 48804,
-			     49169, 49534, 50083, 50630, 51179, 53736, 54832} ;
+			     49169, 49534, 50083, 50630, 51179, 53736, 54832, 56109} ;
 double XTime::LEAPSECS[]  = {10, 11, 12,13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
-			     26, 27, 28, 29, 30, 31, 32, 33, 34} ;
+			     26, 27, 28, 29, 30, 31, 32, 33, 34, 35} ;
 time_t XTime::WALLCLOCK0      ;      // Wallclock time when leap seconds were read
 
 static int daymonth[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31} ;
@@ -127,7 +127,7 @@ void XTime::setleaps (double dt)
 
     // File could not be found; use the ones we know about when coding
     else if ( !NUMLEAPSECS ) {
-      nums = 25 ;                 // Leap seconds: 1972.0 through 2009.0
+      nums = 26 ;                 // Leap seconds: 1972.0 through 2013.0
       NUMLEAPSECS = nums ;
     }
 
@@ -258,8 +258,8 @@ void XTime::set (long tti, double ttf, TimeSys ts, TimeFormat tf,
       while ( ( k < LEAPSMJD[i] ) && i ) {
 	i-- ;
       }
-      if ( ( i < NUMLEAPSECS-1 ) && ( j+1 == LEAPSMJD[i+1] ) &&
-	   ( (k + x + timeZero - LEAPSMJD[i+1]) < SEC2DAY  ) && i ) {
+      if ( ( i < NUMLEAPSECS-1 ) && ( k+1 == LEAPSMJD[i+1] ) &&
+          ( (LEAPSMJD[i+1] - k + x + timeZero) < SEC2DAY  ) && i ) {
 	i-- ;
 	leapflag = 1 ;
       }

--- a/Chandra/test_Time.py
+++ b/Chandra/test_Time.py
@@ -33,6 +33,8 @@ class TestConvert(unittest.TestCase):
     def test_secs(self):
         self.assertEqual('%.3f' % DateTime(20483020.).secs, '20483020.000')
         self.assertEqual(DateTime(20483020.).date, '1998:238:01:42:36.816')
+        self.assertEqual(DateTime('2012:001:00:00:00.000').secs, 441763266.18399996)
+        self.assertEqual(DateTime(473385667.18399996).date, '2013:001:00:00:00.000')
 
     def test_fits2secs(self):
         self.assertEqual(convert('1998-01-01T00:00:30'), 30)
@@ -47,6 +49,8 @@ class TestConvert(unittest.TestCase):
 
     def test_mjd(self):
         self.assertEqual(DateTime('2007-01-01T00:00:00').mjd, 54100.999245555999)
+        self.assertEqual(DateTime('2012-01-01T00:00:00').mjd, 55926.999233981)
+        self.assertEqual(DateTime('2013-01-01T00:00:00').mjd, 56292.999222407)
 
     def test_greta(self):
         self.assertEqual(DateTime('2007001.010203').date, '2007:001:01:02:03.000')

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(name='Chandra.Time',
       description='Convert between various time formats relevant to Chandra',
       author_email = 'taldcroft@cfa.harvard.edu',
       py_modules = ['Chandra.axTime3', 'Chandra.Time'],
-      version='1.12',
+      version='1.13',
       zip_safe=False,
       test_suite = "Chandra.test_Time",
 


### PR DESCRIPTION
Latest version of XTime.C (XTime.C,v 6.8 2012/01/23 17:09:48) contains
a diff in leap second handling.  All Chandra.Time tests pass including those
dependent on leap second handling.  Added new test that confirms the
2012-June-30 leap second is in place.
