### PR TITLE
Use chandra_time modules for Chandra.Time

### DIFF
--- a/chandra_time/__init__.py
+++ b/chandra_time/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import ska_helpers
 
-from .Time import *  # noqa
+from chandra_time.Time import *  # noqa
 
 __version__ = ska_helpers.get_version('chandra_time')
 


### PR DESCRIPTION
## Description

This is an idea to fix #57 in which the modules and classes from the `chandra_time` package are used for both `chandra_time` and `Chandra.Time`. 

This is a little weird and I'm not sure if there is some gotcha with this solution, but it does seem to work.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #57 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

I installed this into dev ska with `pip install .`. Then did some tests:
```
(ska3-dev) ➜  Chandra.Time git:(master) ✗ pip install .
Processing /Users/aldcroft/git/Chandra.Time
  Preparing metadata (setup.py) ... done
Building wheels for collected packages: chandra-time
  Building wheel for chandra-time (setup.py) ... done
  Created wheel for chandra-time: filename=chandra_time-4.1.2.dev0+g2c12c8d.d20230329-cp310-cp310-macosx_10_9_x86_64.whl size=56729 sha256=6f6c90523f8fa6b647e3c2ba0fd9c991ffd164bc2ad62d907fad6baca54a440e
  Stored in directory: /private/var/folders/zn/910d7qgd1ydd4bvww62b6b9r0000gp/T/pip-ephem-wheel-cache-wtflo7fp/wheels/14/db/99/8a1d858b5af0267fa44a4fce2e3154d13847261f9b179b524e
Successfully built chandra-time
Installing collected packages: chandra-time
  Attempting uninstall: chandra-time
    Found existing installation: chandra-time 4.1.1
    Uninstalling chandra-time-4.1.1:
      Successfully uninstalled chandra-time-4.1.1
Successfully installed chandra-time-4.1.2.dev0+g2c12c8d.d20230329

(ska3-dev) ➜  Chandra.Time git:(master) ✗ cd ~
(ska3-dev) ➜  ~ ipython
Python 3.10.8 | packaged by conda-forge | (main, Nov 22 2022, 08:27:35) [Clang 14.0.6 ]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.8.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import Chandra.Time

In [2]: Chandra.Time.test()
=========================================================== test session starts ============================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.10/site-packages
plugins: timeout-2.1.0, anyio-3.6.2
collected 44 items                                                                                                                         

Chandra/Time/tests/test_Time.py ............................................                                                         [100%]

============================================================= warnings summary =============================================================
numpy/ctypeslib.py:137
  /Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.10/site-packages/numpy/ctypeslib.py:137: DeprecationWarning: 
  
    `numpy.distutils` is deprecated since NumPy 1.23.0, as a result
    of the deprecation of `distutils` itself. It will be removed for
    Python >= 3.12. For older Python versions it will remain present.
    It is recommended to use `setuptools < 60.0` for those Python versions.
    For more details, see:
      https://numpy.org/devdocs/reference/distutils_status_migration.html 
  
  
    from numpy.distutils.misc_util import get_shared_lib_extension

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================== 44 passed, 1 warning in 2.02s =======================================================
Out[2]: False

In [3]: import chandra_time

In [4]: chandra_time.test()
=========================================================== test session starts ============================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/miniconda3/envs/ska3-dev/lib/python3.10/site-packages
plugins: timeout-2.1.0, anyio-3.6.2
collected 44 items                                                                                                                         

chandra_time/tests/test_Time.py ............................................                                                         [100%]

============================================================ 44 passed in 1.14s ============================================================
Out[4]: False

In [5]: chandra_time.DateTime is Chandra.Time.DateTime
Out[5]: True

In [6]: t1 = chandra_time.DateTime()

In [7]: t2 = Chandra.Time.DateTime()

In [8]: t12 = chandra_time.DateTime(t2)

In [9]: t21 = Chandra.Time.DateTime(t1)

In [10]: chandra_time.__version__
Out[10]: '4.1.2.dev0+g2c12c8d.d20230329'
```

