### PR TITLE
Support cxotime now sentinel and env var

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python 3.12
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.12
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python 3.12
       uses: actions/setup-python@v1
       with:
-        python-version: 3.12
+        python-version: "3.12"
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/chandra_time/Time.py
+++ b/chandra_time/Time.py
@@ -73,13 +73,6 @@ specifically select a format use the 'format' option.::
   >>> u = DateTime(1125538824.0, format='unix')
   >>> u.date
   '2005:244:01:40:24.000'
-  >>> mxd = mx.DateTime.Parser.DateTimeFromString('1999-01-01 12:13:14')
-  >>> DateTime(mxd).fits
-  '1999-01-01T12:14:18.184'
-  >>> DateTime(mxd).date
-  '1999:001:12:13:14.000'
-  >>> DateTime(mxd).mxDateTime.strftime('%c')
-  'Fri Jan  1 12:13:14 1999'
   >>> DateTime('2007122.01020340').date
   '2007:122:01:02:03.400'
 
@@ -88,11 +81,18 @@ If no input time is supplied when creating the object then the current time is u
   >>> DateTime().fits
   '2009-11-14T18:24:14.504'
 
+If the ``CXOTIME_NOW`` environment variable is set then it will be used as the current
+time. This is useful for testing.
+
+   >>> import os
+   >>> os.environ['CXOTIME_NOW'] = '2020:001:00:00:00.000'
+   >>> DateTime().date
+   '2020:001:00:00:00.000'
+
 For convenience a DateTime object can be initialized from another DateTime object.
 
   >>> t = DateTime()
   >>> u = DateTime(t)
-
 
 Sequences of dates
 ------------------

--- a/chandra_time/Time.py
+++ b/chandra_time/Time.py
@@ -731,7 +731,6 @@ class DateTime(object):
       unix       Unix time (since 1970.0)                        utc
       greta      YYYYDDD.hhmmss[sss]                             utc
       year_doy   YYYY:DDD                                        utc
-      mxDateTime mx.DateTime object                              utc
       frac_year  YYYY.ffffff = date as a floating point year     utc
       plotdate   Matplotlib plotdate (days since 0001-01-01)     utc
     ============ ==============================================  =======

--- a/chandra_time/tests/test_Time.py
+++ b/chandra_time/tests/test_Time.py
@@ -350,4 +350,6 @@ def test_cxotime_now_env_var(monkeypatch):
     assert DateTime(CxoTime.NOW).date == date
     assert DateTime().date == date
     assert DateTime(None).date == date
+
+    # Ensure that env var does not disrupt normal operation
     assert DateTime('2025:001:00:00:01.250').date == '2025:001:00:00:01.250'

--- a/chandra_time/tests/test_Time.py
+++ b/chandra_time/tests/test_Time.py
@@ -4,7 +4,15 @@ import time
 import numpy as np
 import pytest
 
-from ..Time import DateTime, convert, convert_vals, date2secs, secs2date, use_noon_day_start
+from ..Time import (
+    DateTime,
+    convert,
+    convert_vals,
+    date2secs,
+    secs2date,
+    use_noon_day_start,
+    ChandraTimeError,
+)
 from cxotime import CxoTime
 from astropy.time import Time
 
@@ -316,3 +324,30 @@ def test_date_attributes():
                       ('day', 9),
                       ('wday', 1)):
         assert getattr(t, attr) == val
+
+
+def test_cxotime_now():
+    """Check instantiating with CxoTime.NOW results in current time."""
+    # These two commands should run within a 2 sec of each other, even on the slowest
+    # machine.
+    date1 = DateTime(CxoTime.NOW)
+    date2 = DateTime()
+    assert abs(date2.secs - date1.secs) < 2.0
+
+
+def test_with_object_input():
+    """Check DateTime fails when called with an object() that is not CxoTime.NOW"""
+    with pytest.raises(ChandraTimeError):
+        DateTime(object()).iso
+
+
+def test_cxotime_now_env_var(monkeypatch):
+    """Check instantiating with CxoTime.NOW results in current time."""
+    # These two commands should run within a 2 sec of each other, even on the slowest
+    # machine.
+    date = '2015:160:02:24:01.250'
+    monkeypatch.setenv('CXOTIME_NOW', date)
+    assert DateTime(CxoTime.NOW).date == date
+    assert DateTime().date == date
+    assert DateTime(None).date == date
+    assert DateTime('2025:001:00:00:01.250').date == '2025:001:00:00:01.250'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,7 @@ release = __version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+# language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
## Description

This makes `DateTime` compatible with `CxoTime` for handling of the current time:
- Allow `CxoTime.NOW` as an input to signify initializing to the "current time".
- Allow the `CXOTIME_NOW` environment to define the "current time" if defined.

This PR also removes documentation mentions of the old `mx` format, which is no longer available in Ska.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds support described, no back-compatibility changes.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-2025.0rc2) ➜  chandra_time git:(support-cxotime-now-sentinel-and-env-var) git rev-parse --short HEAD
962653c
(ska3-flight-2025.0rc2) ➜  chandra_time git:(support-cxotime-now-sentinel-and-env-var) pytest                    
================================================== test session starts ===================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Volumes/git/chandra_time
configfile: pytest.ini
plugins: doctestplus-1.3.0, anyio-4.7.0, timeout-2.3.1
collected 47 items                                                                                                       

chandra_time/tests/test_Time.py ...............................................                                    [100%]

=================================================== 47 passed in 1.33s ===================================================
```
Independent check of unit tests by Jean
- [x] osx arm64
```
(2025.1rc1) flame:chandra_time jean$ pytest
============================================================================================== test session starts ==============================================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git/chandra_time
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 47 items                                                                                                                                                                                              

chandra_time/tests/test_Time.py ...............................................                                                                                                                           [100%]

============================================================================================== 47 passed in 1.62s ===============================================================================================
(2025.1rc1) flame:chandra_time jean$ git rev-parse HEAD
2acfd6f883766305e91e277fd1f46c9eaa08dc9e
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
