### PR TITLE
Allow for quantity-string time delta as CxoTime initializer

### DIFF
--- a/chandra_time/Time.py
+++ b/chandra_time/Time.py
@@ -2,9 +2,9 @@
 """
 Convert between various time formats relevant to Chandra.
 
-``chandra_time`` provides a simple interface to the C++ time conversion
-utility axTime3 (which itself is a wrapper for XTime) written by Arnold
-Rots.  Chandra_time also supports some useful additional time formats.
+``chandra_time`` provides a simple interface to the C++ time conversion utility axTime3
+(which itself is a wrapper for XTime) written by Arnold Rots.  Chandra_time also
+supports some useful additional time formats.
 
 .. warning::
    The ``chandra_time`` package and ``DateTime`` class are deprecated. All new code
@@ -88,6 +88,16 @@ time. This is useful for testing.
    >>> os.environ['CXOTIME_NOW'] = '2020:001:00:00:00.000'
    >>> DateTime().date
    '2020:001:00:00:00.000'
+
+If the input time is a single `delta time string <https://docs.astropy.org/en/stable/api/astropy.time.TimeDeltaQuantityString.html>`_, then the ``DateTime`` object is
+initialized as the current time (or ``CXOTIME_NOW``) plus the delta time. A delta time
+string is of the form ``"+/-1yr 2d 3hr 4.2min 10.25s"``. One year is exactly 365.25 days,
+not one calendar year. Likewise one day is always 86400.0 sec. The components must be in
+``yr, d, hr, min, s`` order, but each component is optional. Assuming the same
+``CXOTIME_NOW`` value above:
+
+   >>> DateTime("1d 2hr 3.5min 4s").date
+   '2020:002:02:03:34.000'
 
 For convenience a DateTime object can be initialized from another DateTime object.
 
@@ -709,6 +719,23 @@ def _convert(time_in, sys_in, fmt_in, sys_out, fmt_out):
 
     return time_out
 
+# Regex to parse a delta time string like "1.02yr 2.2d 3.12hr 4.322min 5.6s" where each
+# element is optional but order is fixed. This is copied from astropy/time/formats.py.
+re_float = r"(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?"
+re_delta_time = re.compile(
+    rf"""^ \s*
+    (?P<sign>[-+])? \s*  # Optional sign
+    (?=[^-+\s])  # At least one character which is not a sign or whitespace
+    ((?P<yr>{re_float}) \s* yr \s*)?
+    ((?P<d>{re_float}) \s* d \s*)?
+    ((?P<hr>{re_float}) \s* hr \s*)?
+    ((?P<min>{re_float}) \s* min \s*)?
+    ((?P<s>{re_float}) \s* s)?
+    \s* $
+    """,
+    re.VERBOSE,
+)
+
 
 class DateTime(object):
     """
@@ -790,6 +817,13 @@ class DateTime(object):
             format = 'secs'
         except (AttributeError, ImportError, AssertionError, ChandraTimeError):
             pass
+
+        # Special case a single delta time string like "1hr 3min 2.05s" which is
+        # relative to the current time.
+        if isinstance(time_in, str) and re_delta_time.match(time_in):
+            from cxotime import CxoTime
+            time_in = CxoTime(time_in).date
+            format = "date"
 
         try:
             self.time_in = time_in.time_in

--- a/chandra_time/tests/test_Time.py
+++ b/chandra_time/tests/test_Time.py
@@ -326,13 +326,15 @@ def test_date_attributes():
         assert getattr(t, attr) == val
 
 
-def test_cxotime_now():
+def test_cxotime_now(monkeypatch):
     """Check instantiating with CxoTime.NOW results in current time."""
     # These two commands should run within a 2 sec of each other, even on the slowest
     # machine.
+    monkeypatch.setenv("CXOTIME_NOW", "2020:001")
     date1 = DateTime(CxoTime.NOW)
     date2 = DateTime()
-    assert abs(date2.secs - date1.secs) < 2.0
+    assert date1.date == "2020:001:00:00:00.000"
+    assert date1.date == date2.date
 
 
 def test_with_object_input():
@@ -353,3 +355,9 @@ def test_cxotime_now_env_var(monkeypatch):
 
     # Ensure that env var does not disrupt normal operation
     assert DateTime('2025:001:00:00:01.250').date == '2025:001:00:00:01.250'
+
+
+def test_delta_time_str_scalar(monkeypatch):
+    monkeypatch.setenv("CXOTIME_NOW", "2020:001")
+    tm = DateTime("1d 2hr 3.5min 4.25s")
+    assert tm.date == "2020:002:02:03:34.250"


### PR DESCRIPTION
## Description

This is a long-standing desire of mine to allow supplying a [delta time](https://docs.astropy.org/en/stable/api/astropy.time.TimeDeltaQuantityString.html) offset from now to initialize `DateTime`.
This is in the form ``"+/-1yr 2d 3hr 4.2min 10.25s"``.  Any function or command line tool that uses Ska
``CxoTime`` or ``DateTime`` will work with this format.

This is especially convenient for command line arguments like `--start=-14d --stop=-7d`, or similar for any function that has `DateTimeLike` `start` / `stop` args.

This leverages the same functionality in `CxoTime`.

## Requires
- https://github.com/sot/cxotime/pull/54

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds a new way to initialize DateTime.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
# Including https://github.com/sot/cxotime/pull/54 @ 19f4f95 in the path

(ska3) ➜  chandra_time git:(init-with-delta-time) git rev-parse --short HEAD                       
024fdfb
(ska3) ➜  chandra_time git:(init-with-delta-time) env PYTHONPATH=/Users/aldcroft/git/cxotime pytest
======================================= test session starts ========================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/aldcroft/git/chandra_time
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 48 items                                                                                 

chandra_time/tests/test_Time.py ................................................             [100%]

======================================== 48 passed in 1.39s ========================================

```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.