### PR TITLE
Replace repr() with str() when passing to axTime3.convert_time

### DIFF
--- a/chandra_time/Time.py
+++ b/chandra_time/Time.py
@@ -586,7 +586,6 @@ def convert_vals(vals, format_in, format_out):
     if vals.dtype.kind == 'S':
         vals = np.char.decode(vals, 'ascii')
 
-
     # If the input is already string-like then pass straight to convert_time.
     # Otherwise convert to string with str().
     if vals.dtype.kind == 'U':

--- a/chandra_time/Time.py
+++ b/chandra_time/Time.py
@@ -586,13 +586,20 @@ def convert_vals(vals, format_in, format_out):
     if vals.dtype.kind == 'S':
         vals = np.char.decode(vals, 'ascii')
 
+    def legacy_repr(x):
+        # If it's a NumPy scalar (np.float64, np.int64, np.str_, np.bool_, etc.)
+        # convert to the corresponding Python scalar; otherwise leave it as-is.
+        if isinstance(x, np.generic):
+            x = x.item()
+        return repr(x)
+
     # If the input is already string-like then pass straight to convert_time.
     # Otherwise convert to string with repr().
     if vals.dtype.kind == 'U':
         outs = [axTime3.convert_time(val, sys_in, fmt_in, sys_out, fmt_out)
                 for val in vals.flatten()]
     else:
-        outs = [axTime3.convert_time(repr(val), sys_in, fmt_in, sys_out, fmt_out)
+        outs = [axTime3.convert_time(legacy_repr(val), sys_in, fmt_in, sys_out, fmt_out)
                 for val in vals.flatten()]
 
     if (six.PY3

--- a/chandra_time/Time.py
+++ b/chandra_time/Time.py
@@ -586,20 +586,14 @@ def convert_vals(vals, format_in, format_out):
     if vals.dtype.kind == 'S':
         vals = np.char.decode(vals, 'ascii')
 
-    def legacy_repr(x):
-        # If it's a NumPy scalar (np.float64, np.int64, np.str_, np.bool_, etc.)
-        # convert to the corresponding Python scalar; otherwise leave it as-is.
-        if isinstance(x, np.generic):
-            x = x.item()
-        return repr(x)
 
     # If the input is already string-like then pass straight to convert_time.
-    # Otherwise convert to string with repr().
+    # Otherwise convert to string with str().
     if vals.dtype.kind == 'U':
         outs = [axTime3.convert_time(val, sys_in, fmt_in, sys_out, fmt_out)
                 for val in vals.flatten()]
     else:
-        outs = [axTime3.convert_time(legacy_repr(val), sys_in, fmt_in, sys_out, fmt_out)
+        outs = [axTime3.convert_time(str(val), sys_in, fmt_in, sys_out, fmt_out)
                 for val in vals.flatten()]
 
     if (six.PY3


### PR DESCRIPTION
## Description

repr() was intended to get the number to as many digits as available to pass to convert_time, in modern Python using str() should be fine.  

This has no impact in numpy 1.26.4 but is required for this code to work with numpy > 2 as the new repr behavior (includes the np type in the string) doesn't work with axTime3.convert .  With Python > 3.1, str() should have enough digits for this code change to be non-impacting.

## Interface impacts
None.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(latest) flame:chandra_time jean$ git rev-parse HEAD
0bbb3953e1d9cbd48dcbe5512085ad85f7824264
(latest) flame:chandra_time jean$ pytest
====================================================== test session starts =======================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git/chandra_time
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 48 items                                                                                                               

chandra_time/tests/test_Time.py ................................................                                           [100%]

======================================================= 48 passed in 1.32s
```
And on the latest hope rc
```
(ska3-flight-2026.0rc4) flame:chandra_time jean$ git rev-parse HEAD
0bbb3953e1d9cbd48dcbe5512085ad85f7824264
(ska3-flight-2026.0rc4) flame:chandra_time jean$ pytest
==================================================================== test session starts ====================================================================
platform darwin -- Python 3.13.10, pytest-9.0.1, pluggy-1.6.0
rootdir: /Users/jean/git/chandra_time
configfile: pytest.ini
plugins: anyio-4.12.0, timeout-2.4.0
collected 48 items                                                                                                                                          

chandra_time/tests/test_Time.py ................................................                                                                      [100%]

==================================================================== 48 passed in 3.46
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
